### PR TITLE
[BREAKING] Change the table syntax from `---...---` to `(...)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Here is an example of Tabular-JSON:
     "swimming",
     "biking",
   ],
-  "friends": ###
+  "friends": (
     "id", "name",  "address"."city", "address"."street"
     2,    "joe",   "New York",       "1st Ave"
     3,    "sarah", "Washington",     "18th Street NW"
-  ---,
+  ),
   "address": {
     "city": "New York",
     "street": "1st Ave",
@@ -50,11 +50,11 @@ import { parse, stringify } from '@tabular-json/tabular-json'
 const text = `{
   "id": 1,
   "name": "Brandon",
-  "friends": ###
+  "friends": (
     "id", "name"
     2,    "Joe"
     3,    "Sarah"
-  ---
+  )
 }`
 
 const data = parse(text)
@@ -68,12 +68,12 @@ const updatedText = stringify(data, {
 // {
 //   "id": 1,
 //   "name": "Brandon",
-//   "friends": ###
+//   "friends": (
 //     "id", "name"
 //     2,    "Joe"
 //     3,    "Sarah"
 //     4,    "Alan"
-//   ---
+//   )
 // }
 ```
 
@@ -134,16 +134,16 @@ const data = {
 // Use the default table strategy
 console.log(stringify(data, { indentation: 2 }))
 // {
-//   "careTakers": ###
+//   "careTakers": (
 //     "id", "name"
 //     1001, "Joe"
 //     1002, "Sarah"
-//   ---,
-//   "animals": ###
+//   ),
+//   "animals": (
 //     "animalId", "name",     "description"
 //     1,          "Elephant", "Elephants are the largest living land animals."
 //     2,          "Giraffe",  "The giraffe is the tallest living terrestrial animal on Earth"
-//   ---
+//   )
 // }
 
 // Do not output tables containing long strings as table
@@ -155,11 +155,11 @@ console.log(
   })
 )
 // {
-//   "careTakers": ###
+//   "careTakers": (
 //     "id", "name"
 //     1001, "Joe"
 //     1002, "Sarah"
-//   ---,
+//   ),
 //   "animals": [
 //     {
 //       "animalId": 1,
@@ -190,11 +190,11 @@ console.log(
   })
 )
 // {
-//   "careTakers": ###
+//   "careTakers": (
 //     "id", "name"
 //     1001, "Joe"
 //     1002, "Sarah"
-//   ---,
+//   ),
 //   "animals": [
 //     {
 //       "animalId": 1,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here is an example of Tabular-JSON:
     "swimming",
     "biking",
   ],
-  "friends": ---
+  "friends": ###
     "id", "name",  "address"."city", "address"."street"
     2,    "joe",   "New York",       "1st Ave"
     3,    "sarah", "Washington",     "18th Street NW"
@@ -50,7 +50,7 @@ import { parse, stringify } from '@tabular-json/tabular-json'
 const text = `{
   "id": 1,
   "name": "Brandon",
-  "friends": ---
+  "friends": ###
     "id", "name"
     2,    "Joe"
     3,    "Sarah"
@@ -68,7 +68,7 @@ const updatedText = stringify(data, {
 // {
 //   "id": 1,
 //   "name": "Brandon",
-//   "friends": ---
+//   "friends": ###
 //     "id", "name"
 //     2,    "Joe"
 //     3,    "Sarah"
@@ -134,12 +134,12 @@ const data = {
 // Use the default table strategy
 console.log(stringify(data, { indentation: 2 }))
 // {
-//   "careTakers": ---
+//   "careTakers": ###
 //     "id", "name"
 //     1001, "Joe"
 //     1002, "Sarah"
 //   ---,
-//   "animals": ---
+//   "animals": ###
 //     "animalId", "name",     "description"
 //     1,          "Elephant", "Elephants are the largest living land animals."
 //     2,          "Giraffe",  "The giraffe is the tallest living terrestrial animal on Earth"
@@ -155,7 +155,7 @@ console.log(
   })
 )
 // {
-//   "careTakers": ---
+//   "careTakers": ###
 //     "id", "name"
 //     1001, "Joe"
 //     1002, "Sarah"
@@ -190,7 +190,7 @@ console.log(
   })
 )
 // {
-//   "careTakers": ---
+//   "careTakers": ###
 //     "id", "name"
 //     1001, "Joe"
 //     1002, "Sarah"

--- a/specification/TabularJSON.g4
+++ b/specification/TabularJSON.g4
@@ -24,9 +24,9 @@ array
     : '[' ws value ws (',' ws value ws)* trailing? ']'
     | '[' ws ']' ;
 
-table : '###' wst '\n'
+table : '(' wst '\n'
     contents '\n'
-    wst '---' ;
+    wst ')' ;
 
 contents : header '\n' ws rows ;
 header   : field (',' field)* ;

--- a/specification/TabularJSON.g4
+++ b/specification/TabularJSON.g4
@@ -24,7 +24,7 @@ array
     : '[' ws value ws (',' ws value ws)* trailing? ']'
     | '[' ws ']' ;
 
-table : '---' wst '\n'
+table : '###' wst '\n'
     contents '\n'
     wst '---' ;
 

--- a/src/content/pages/implementations.md
+++ b/src/content/pages/implementations.md
@@ -25,7 +25,7 @@ import { parse, stringify } from '@tabular-json/tabular-json'
 const text = `{
   "id": 1,
   "name": "Brandon",
-  "friends": ---
+  "friends": ###
     "id", "name"
     2,    "Joe"
     3,    "Sarah"
@@ -40,7 +40,7 @@ const updatedText = stringify(data, { indentation: 2, trailingCommas: false })
 // {
 //   "id": 1,
 //   "name": "Brandon",
-//   "friends": ---
+//   "friends": ###
 //     "id", "name"
 //     2,    "Joe"
 //     3,    "Sarah"
@@ -67,7 +67,7 @@ from tabularjson import parse, stringify, StringifyOptions
 text = """{
     "id": 1,
     "name": "Brandon",
-    "friends": ---
+    "friends": ###
     "id", "name"
         2,    "Joe"
         3,    "Sarah"
@@ -94,7 +94,7 @@ print(updatedText)
 # {
 #     "id": 1,
 #     "name": "Brandon",
-#     "friends": ---
+#     "friends": ###
 #         "id", "name"
 #         2,    "Joe"
 #         3,    "Sarah"

--- a/src/content/pages/implementations.md
+++ b/src/content/pages/implementations.md
@@ -25,11 +25,11 @@ import { parse, stringify } from '@tabular-json/tabular-json'
 const text = `{
   "id": 1,
   "name": "Brandon",
-  "friends": ###
+  "friends": (
     "id", "name"
     2,    "Joe"
     3,    "Sarah"
-  ---
+  )
 }`
 
 const data = parse(text)
@@ -40,12 +40,12 @@ const updatedText = stringify(data, { indentation: 2, trailingCommas: false })
 // {
 //   "id": 1,
 //   "name": "Brandon",
-//   "friends": ###
+//   "friends": (
 //     "id", "name"
 //     2,    "Joe"
 //     3,    "Sarah"
 //     4,    "Alan"
-//   ---
+//   )
 // }
 ```
 
@@ -67,11 +67,11 @@ from tabularjson import parse, stringify, StringifyOptions
 text = """{
     "id": 1,
     "name": "Brandon",
-    "friends": ###
+    "friends": (
     "id", "name"
         2,    "Joe"
         3,    "Sarah"
-    ---
+    )
 }
 """
 
@@ -94,12 +94,12 @@ print(updatedText)
 # {
 #     "id": 1,
 #     "name": "Brandon",
-#     "friends": ###
+#     "friends": (
 #         "id", "name"
 #         2,    "Joe"
 #         3,    "Sarah"
 #         4,    "Alan"
-#     ---
+#     )
 # }
 ```
 

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -36,11 +36,11 @@ Here is an example of Tabular-JSON data:
     "swimming",
     "biking",
   ],
-  "friends": (
+  "friends": ###
     "id", "name",  "address"."city", "address"."street"
     2,    "joe",   "New York",       "1st Ave"
     3,    "sarah", "Washington",     "18th Street NW"
-  ),
+  ---,
   "address": {
     "city": "New York",
     "street": "1st Ave",

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -36,11 +36,11 @@ Here is an example of Tabular-JSON data:
     "swimming",
     "biking",
   ],
-  "friends": ---
+  "friends": (
     "id", "name",  "address"."city", "address"."street"
     2,    "joe",   "New York",       "1st Ave"
     3,    "sarah", "Washington",     "18th Street NW"
-  ---,
+  ),
   "address": {
     "city": "New York",
     "street": "1st Ave",
@@ -60,7 +60,7 @@ And here a table at root level, with streamable rows:
 So what are the ingredients of Tabular-JSON?
 
 - Take JSON.
-- Add support for CSV-like tables. Tables are wrapped in a `---` block (except at root level), and they support nested objects.
+- Add support for CSV-like tables. Tables are wrapped in a block starting with `###` and ending with `---` (except at root level), and they support nested objects.
 - Add support for trailing commas to make it more streaming-friendly.
 - Add support for positive infinity (`inf`), negative infinity (`-inf`), and `nan`.
 - Add support for line comments (`// ...`) and block comments (`/* ... */`).
@@ -94,7 +94,7 @@ Tabular-JSON supports the following data types:
 | ---------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | object     | `{ "name": "Joe", "age": 24 }`                                              | Starts with `{`                                                                                                  |
 | array      | `[7.4, 5.2, 8.1]`                                                           | Starts with `[`                                                                                                  |
-| table      | <pre>---<br>`"id","name"`<br/>`1018,"Joe"`<br/>`1078,"Sarah"`<br/>---</pre> | Starts with `---`                                                                                                |
+| table      | <pre>###<br>`"id","name"`<br/>`1018,"Joe"`<br/>`1078,"Sarah"`<br/>---</pre> | Starts with `###`                                                                                                |
 | root table | <pre>`"id","name"`<br/>`1018,"Joe"`<br/>`1078,"Sarah"`</pre>                | Starts with a string followed by a comma and another string, or a string followed by a newline and another value |
 | boolean    | `true`                                                                      | Equals `true` or `false`                                                                                         |
 | null       | `null`                                                                      | Equals `null`                                                                                                    |

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -36,11 +36,11 @@ Here is an example of Tabular-JSON data:
     "swimming",
     "biking",
   ],
-  "friends": ###
+  "friends": (
     "id", "name",  "address"."city", "address"."street"
     2,    "joe",   "New York",       "1st Ave"
     3,    "sarah", "Washington",     "18th Street NW"
-  ---,
+  ),
   "address": {
     "city": "New York",
     "street": "1st Ave",
@@ -60,7 +60,7 @@ And here a table at root level, with streamable rows:
 So what are the ingredients of Tabular-JSON?
 
 - Take JSON.
-- Add support for CSV-like tables. Tables are wrapped in a block starting with `###` and ending with `---` (except at root level), and they support nested objects.
+- Add support for CSV-like tables. Tables are wrapped in round brackets `(` and `)` except at root level, and they support nested objects.
 - Add support for trailing commas to make it more streaming-friendly.
 - Add support for positive infinity (`inf`), negative infinity (`-inf`), and `nan`.
 - Add support for line comments (`// ...`) and block comments (`/* ... */`).
@@ -90,16 +90,16 @@ Tabular-JSON files have a `*.tjson` extension, for example `data.tjson`
 
 Tabular-JSON supports the following data types:
 
-| Data type  | Example                                                                     | Detection                                                                                                        |
-| ---------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| object     | `{ "name": "Joe", "age": 24 }`                                              | Starts with `{`                                                                                                  |
-| array      | `[7.4, 5.2, 8.1]`                                                           | Starts with `[`                                                                                                  |
-| table      | <pre>###<br>`"id","name"`<br/>`1018,"Joe"`<br/>`1078,"Sarah"`<br/>---</pre> | Starts with `###`                                                                                                |
-| root table | <pre>`"id","name"`<br/>`1018,"Joe"`<br/>`1078,"Sarah"`</pre>                | Starts with a string followed by a comma and another string, or a string followed by a newline and another value |
-| boolean    | `true`                                                                      | Equals `true` or `false`                                                                                         |
-| null       | `null`                                                                      | Equals `null`                                                                                                    |
-| number     | `-2.3e5`                                                                    | Starts with a digit or a minus                                                                                   |
-| string     | `"hello world"`                                                             | Starts with `"`                                                                                                  |
+| Data type  | Example                                                                 | Detection                                                                                                        |
+| ---------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| object     | `{ "name": "Joe", "age": 24 }`                                          | Starts with `{`                                                                                                  |
+| array      | `[7.4, 5.2, 8.1]`                                                       | Starts with `[`                                                                                                  |
+| table      | <pre>(<br>`"id","name"`<br/>`1018,"Joe"`<br/>`1078,"Sarah"`<br/>)</pre> | Starts with `(`                                                                                                  |
+| root table | <pre>`"id","name"`<br/>`1018,"Joe"`<br/>`1078,"Sarah"`</pre>            | Starts with a string followed by a comma and another string, or a string followed by a newline and another value |
+| boolean    | `true`                                                                  | Equals `true` or `false`                                                                                         |
+| null       | `null`                                                                  | Equals `null`                                                                                                    |
+| number     | `-2.3e5`                                                                | Starts with a digit or a minus                                                                                   |
+| string     | `"hello world"`                                                         | Starts with `"`                                                                                                  |
 
 ## Differences between JSON and Tabular-JSON
 

--- a/src/lib/parse.test.ts
+++ b/src/lib/parse.test.ts
@@ -66,3 +66,35 @@ for (const [category, testGroups] of Object.entries(testsByCategory)) {
     }
   })
 }
+
+describe('backward compatibility', () => {
+  test('should not allow mixing new and old table syntax (1)', () => {
+    expect(() =>
+      parse(`{
+        "table1": ---
+          "id","name"
+          1,"joe"
+        ---,
+        "table2": (
+          "id","name"
+          1,"joe"
+        )
+      }`)
+    ).toThrow('Cannot mix table syntax (...) with deprecated table syntax ---')
+  })
+
+  test('should not allow mixing new and old table syntax (2)', () => {
+    expect(() =>
+      parse(`{
+        "table1": (
+          "id","name"
+          1,"joe"
+        ),
+        "table2": ---
+          "id","name"
+          1,"joe"
+        ---
+      }`)
+    ).toThrow('Cannot mix table syntax (...) with deprecated table syntax ---')
+  })
+})

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -529,7 +529,7 @@ export function parse(text: string): unknown {
   }
 
   function throwTableRowOrEndExpected() {
-    throw new SyntaxError(`Table row or end of table '---' expected ${gotAt()}`)
+    throw new SyntaxError(`Table row or end of table ')' expected ${gotAt()}`)
   }
 
   function throwArrayItemExpected() {

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -15,7 +15,7 @@ import { isDeepEqual, setIn } from './objects.js'
  */
 export function parse(text: string): unknown {
   let i = 0
-  let backwardCompatibleTables = true // Allow table start --- instead of ###
+  let backwardCompatibleTables = true // In v1, tables where enclosed in three minus characters "---"
 
   const value = parseRootTable()
   if (value === undefined) {
@@ -137,8 +137,9 @@ export function parse(text: string): unknown {
   }
 
   function parseTable(): Record<string, unknown>[] | unknown {
-    if (isTableStart()) {
-      i += 3
+    const tableStart = getTableStart()
+    if (tableStart !== undefined) {
+      i += tableStart.length
       skipTableWhitespace()
       eatTableRowSeparator()
 
@@ -146,37 +147,44 @@ export function parse(text: string): unknown {
       eatTableRowSeparator()
 
       const rows = []
-      while (i < text.length && !isTableEnd(rows)) {
+      while (i < text.length && getTableEnd(rows) === undefined) {
         rows.push(parseTableRow(fields))
         eatTableRowSeparator()
       }
 
-      if (!isTableEnd(rows)) {
+      const tableEnd = getTableEnd(rows)
+      if (tableEnd === undefined) {
         throwTableRowOrEndExpected()
       }
-      i += 3
+      i += tableEnd.length
 
       return rows
     }
   }
 
-  function isTableStart() {
-    if (text.substring(i, i + 3) === '###') {
+  function getTableStart(): '(' | '---' | undefined {
+    if (text[i] === '(') {
       backwardCompatibleTables = false
-      return true
+      return '('
     }
 
     if (backwardCompatibleTables && text.substring(i, i + 3) === '---') {
       backwardCompatibleTables = false
-      return true
+      return '---'
     }
 
-    return false
+    return undefined
   }
 
-  function isTableEnd(rows: Record<string, unknown>[]) {
-    // TODO: testing rows.length > 0 is a workaround for some issues with nested tables, but it is no solid solution
-    return rows.length > 0 && text.substring(i, i + 3) === '---'
+  function getTableEnd(rows: Record<string, unknown>[]): ')' | '---' | undefined {
+    if (text[i] === ')') {
+      return ')'
+    }
+
+    // testing rows.length > 0 is a workaround for some issues with nested tables, but it is no solid solution
+    return backwardCompatibleTables && rows.length > 0 && text.substring(i, i + 3) === '---'
+      ? '---'
+      : undefined
   }
 
   function parseTableFields(): TableField[] {

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -482,7 +482,7 @@ export function parse(text: string): unknown {
   function eatTableRowSeparator() {
     // must start with a newline
     if (text.charCodeAt(i) !== codeNewline) {
-      throw new SyntaxError(`Newline '\n' expected after table row ${gotAt()}`)
+      throw new SyntaxError(`Newline '\\n' expected after table row ${gotAt()}`)
     }
 
     // can optionally be followed by more newlines and whitespace and comments

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -15,6 +15,7 @@ import { isDeepEqual, setIn } from './objects.js'
  */
 export function parse(text: string): unknown {
   let i = 0
+  let backwardCompatibleTables = true // Allow table start --- instead of ###
 
   const value = parseRootTable()
   if (value === undefined) {
@@ -160,10 +161,32 @@ export function parse(text: string): unknown {
   }
 
   function isTableStart() {
-    return text.charCodeAt(i) === codeMinus && text.substring(i, i + 3) === '---'
+    if (text.charCodeAt(i) === codeNumberSign && text.substring(i, i + 3) === '###') {
+      // We're using v2 table start, disable backward compatibility
+      backwardCompatibleTables = false
+      return true
+    }
+
+    // Backward compatibility with v1, where table start was --- instead of ###
+    if (
+      backwardCompatibleTables &&
+      text.charCodeAt(i) === codeMinus &&
+      text.substring(i, i + 3) === '---'
+    ) {
+      backwardCompatibleTables = true
+      return true
+    }
+
+    return false
   }
 
   function isTableEnd() {
+    if (!backwardCompatibleTables) {
+      return text.charCodeAt(i) === codeMinus && text.substring(i, i + 3) === '---'
+    }
+
+    // TODO: the following lookahead is for backward compatibility with v1. It solves
+    //  some cases in v1 where table start and end cannot correctly determined.
     if (text.substring(i, i + 3) !== '---') {
       return false
     }
@@ -605,6 +628,7 @@ const codeNewline = 0xa // "\n"
 const codeTab = 0x9 // "\t"
 const codeReturn = 0xd // "\r"
 const codeDoubleQuote = 0x0022 // "
+const codeNumberSign = 0x0023 // #
 const codePlus = 0x2b // "+"
 const codeMinus = 0x2d // "-"
 const codeZero = 0x30

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -15,7 +15,8 @@ import { isDeepEqual, setIn } from './objects.js'
  */
 export function parse(text: string): unknown {
   let i = 0
-  let backwardCompatibleTables = true // In v1, tables where enclosed in three minus characters "---"
+  let tableVersion1 = false // tables enclosed in ---, deprecated since v2
+  let tableVersion2 = false // tables enclosed in (...)
 
   const value = parseRootTable()
   if (value === undefined) {
@@ -164,12 +165,22 @@ export function parse(text: string): unknown {
 
   function getTableStart(): '(' | '---' | undefined {
     if (text[i] === '(') {
-      backwardCompatibleTables = false
+      tableVersion2 = true
+
+      if (tableVersion1) {
+        throw new Error('Cannot mix table syntax (...) with deprecated table syntax ---')
+      }
+
       return '('
     }
 
-    if (backwardCompatibleTables && text.substring(i, i + 3) === '---') {
-      backwardCompatibleTables = false
+    if (text.substring(i, i + 3) === '---') {
+      tableVersion1 = true
+
+      if (tableVersion2) {
+        throw new Error('Cannot mix table syntax (...) with deprecated table syntax ---')
+      }
+
       return '---'
     }
 
@@ -177,14 +188,17 @@ export function parse(text: string): unknown {
   }
 
   function getTableEnd(rows: Record<string, unknown>[]): ')' | '---' | undefined {
-    if (text[i] === ')') {
+    if (tableVersion2 && text[i] === ')') {
       return ')'
     }
 
-    // testing rows.length > 0 is a workaround for some issues with nested tables, but it is no solid solution
-    return backwardCompatibleTables && rows.length > 0 && text.substring(i, i + 3) === '---'
-      ? '---'
-      : undefined
+    // testing rows.length > 0 is a workaround for issues with nested tables
+    // due to not being able to separate table start --- from table end ---
+    if (tableVersion1 && rows.length > 0 && text.substring(i, i + 3) === '---') {
+      return '---'
+    }
+
+    return undefined
   }
 
   function parseTableFields(): TableField[] {

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -176,10 +176,7 @@ export function parse(text: string): unknown {
 
   function isTableEnd(rows: Record<string, unknown>[]) {
     // TODO: testing rows.length > 0 is a workaround for some issues with nested tables, but it is no solid solution
-    return rows.length > 0 &&
-      text.charCodeAt(i) === codeMinus &&
-      text.charCodeAt(i + 1) === codeMinus &&
-      text.charCodeAt(i + 2) === codeMinus
+    return rows.length > 0 && text.substring(i, i + 3) === '---'
   }
 
   function parseTableFields(): TableField[] {
@@ -606,7 +603,6 @@ const codeNewline = 0xa // "\n"
 const codeTab = 0x9 // "\t"
 const codeReturn = 0xd // "\r"
 const codeDoubleQuote = 0x0022 // "
-const codeNumberSign = 0x0023 // #
 const codePlus = 0x2b // "+"
 const codeMinus = 0x2d // "-"
 const codeZero = 0x30

--- a/src/lib/stringify.test.ts
+++ b/src/lib/stringify.test.ts
@@ -75,13 +75,13 @@ describe('should specify option outputAsTable', function () {
 
   test('outputAsTable: always (default)', () => {
     expect(stringify(json)).toEqual(
-      '{"scores":---\n' +
+      '{"scores":###\n' +
         '"values"\n' +
         '[1,2,3]\n' +
         '[5,6,7]\n' +
-        '---,"data":---\n' +
+        '---,"data":###\n' +
         '"measurements"\n' +
-        '---\n' +
+        '###\n' +
         '"x","y"\n' +
         '1,3\n' +
         '2,4\n' +
@@ -92,11 +92,11 @@ describe('should specify option outputAsTable', function () {
 
   test('outputAsTable: noNestedTables', () => {
     expect(stringify(json, { outputAsTable: noNestedTables })).toEqual(
-      '{"scores":---\n' +
+      '{"scores":###\n' +
         '"values"\n' +
         '[1,2,3]\n' +
         '[5,6,7]\n' +
-        '---,"data":[{"measurements":---\n' +
+        '---,"data":[{"measurements":###\n' +
         '"x","y"\n' +
         '1,3\n' +
         '2,4\n' +
@@ -106,7 +106,7 @@ describe('should specify option outputAsTable', function () {
 
   test('outputAsTable: noNestedArrays', () => {
     expect(stringify(json, { outputAsTable: noNestedArrays })).toEqual(
-      '{"scores":[{"values":[1,2,3]},{"values":[5,6,7]}],"data":[{"measurements":---\n' +
+      '{"scores":[{"values":[1,2,3]},{"values":[5,6,7]}],"data":[{"measurements":###\n' +
         '"x","y"\n' +
         '1,3\n' +
         '2,4\n' +

--- a/src/lib/stringify.test.ts
+++ b/src/lib/stringify.test.ts
@@ -75,42 +75,42 @@ describe('should specify option outputAsTable', function () {
 
   test('outputAsTable: always (default)', () => {
     expect(stringify(json)).toEqual(
-      '{"scores":###\n' +
+      '{"scores":(\n' +
         '"values"\n' +
         '[1,2,3]\n' +
         '[5,6,7]\n' +
-        '---,"data":###\n' +
+        '),"data":(\n' +
         '"measurements"\n' +
-        '###\n' +
+        '(\n' +
         '"x","y"\n' +
         '1,3\n' +
         '2,4\n' +
-        '---\n' +
-        '---}'
+        ')\n' +
+        ')}'
     )
   })
 
   test('outputAsTable: noNestedTables', () => {
     expect(stringify(json, { outputAsTable: noNestedTables })).toEqual(
-      '{"scores":###\n' +
+      '{"scores":(\n' +
         '"values"\n' +
         '[1,2,3]\n' +
         '[5,6,7]\n' +
-        '---,"data":[{"measurements":###\n' +
+        '),"data":[{"measurements":(\n' +
         '"x","y"\n' +
         '1,3\n' +
         '2,4\n' +
-        '---}]}'
+        ')}]}'
     )
   })
 
   test('outputAsTable: noNestedArrays', () => {
     expect(stringify(json, { outputAsTable: noNestedArrays })).toEqual(
-      '{"scores":[{"values":[1,2,3]},{"values":[5,6,7]}],"data":[{"measurements":###\n' +
+      '{"scores":[{"values":[1,2,3]},{"values":[5,6,7]}],"data":[{"measurements":(\n' +
         '"x","y"\n' +
         '1,3\n' +
         '2,4\n' +
-        '---}]}'
+        ')}]}'
     )
   })
 })

--- a/src/lib/stringify.ts
+++ b/src/lib/stringify.ts
@@ -109,7 +109,7 @@ export function stringify(json: unknown, options?: StringifyOptions): string {
 
     const fields = getFields(array)
 
-    let str = isRoot ? '' : '###\n'
+    let str = isRoot ? '' : '(\n'
 
     // We pass doIndent=false so nested objects/arrays are not formatted over multiple lines.
     // Nested tables though are always indented (when globalIndentation is set).
@@ -128,7 +128,7 @@ export function stringify(json: unknown, options?: StringifyOptions): string {
       rows.forEach((row) => (str += childIndent + row.join(colSeparator) + '\n'))
     }
 
-    str += isRoot ? '' : indent + '---'
+    str += isRoot ? '' : indent + ')'
 
     return str
   }

--- a/src/lib/stringify.ts
+++ b/src/lib/stringify.ts
@@ -109,7 +109,7 @@ export function stringify(json: unknown, options?: StringifyOptions): string {
 
     const fields = getFields(array)
 
-    let str = isRoot ? '' : '---\n'
+    let str = isRoot ? '' : '###\n'
 
     // We pass doIndent=false so nested objects/arrays are not formatted over multiple lines.
     // Nested tables though are always indented (when globalIndentation is set).

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -75,7 +75,7 @@
       "description": "should parse a table",
       "tests": [
         {
-          "input": "---\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---",
+          "input": "###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---",
           "output": [
             { "id": 1, "name": "Joe" },
             { "id": 2, "name": "Sarah" }
@@ -88,7 +88,7 @@
       "description": "should parse a table with \\r\\n newlines",
       "tests": [
         {
-          "input": "---\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---",
+          "input": "###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---",
           "output": [
             { "id": 1, "name": "Joe" },
             { "id": 2, "name": "Sarah" }
@@ -101,7 +101,7 @@
       "description": "should parse a table with nested properties",
       "tests": [
         {
-          "input": "---\n    \"id\",\"name\",\"address\".\"city\",\"address\".\"street\"\n    1,\"Joe\",\"New York\",\"1st Ave\"\n    2,\"Sarah\",\"Washington\",\"18th Street NW\"\n    ---",
+          "input": "###\n    \"id\",\"name\",\"address\".\"city\",\"address\".\"street\"\n    1,\"Joe\",\"New York\",\"1st Ave\"\n    2,\"Sarah\",\"Washington\",\"18th Street NW\"\n    ---",
           "output": [
             { "id": 1, "name": "Joe", "address": { "city": "New York", "street": "1st Ave" } },
             {
@@ -118,7 +118,7 @@
       "description": "should parse a table with whitespace",
       "tests": [
         {
-          "input": "---\n      \"id\" , \"details\" . \"name\" \n      1 , \"Joe\" \n      2 , \"Sarah\" \n      ---",
+          "input": "###\n      \"id\" , \"details\" . \"name\" \n      1 , \"Joe\" \n      2 , \"Sarah\" \n      ---",
           "output": [
             { "id": 1, "details": { "name": "Joe" } },
             { "id": 2, "details": { "name": "Sarah" } }
@@ -131,7 +131,7 @@
       "description": "should parse a table with missing values",
       "tests": [
         {
-          "input": "---\n\"id\", \"name\"\n1 , \n2 , \"Sarah\" \n---",
+          "input": "###\n\"id\", \"name\"\n1 , \n2 , \"Sarah\" \n---",
           "output": [{ "id": 1 }, { "id": 2, "name": "Sarah" }]
         },
         {
@@ -139,11 +139,11 @@
           "output": [{ "id": 1, "name": "Joe" }, { "name": "Sarah" }]
         },
         {
-          "input": "---\n\"id\", \"name\" \n1 , \"Joe\" \n, \"Sarah\" \n---",
+          "input": "###\n\"id\", \"name\" \n1 , \"Joe\" \n, \"Sarah\" \n---",
           "output": [{ "id": 1, "name": "Joe" }, { "name": "Sarah" }]
         },
         {
-          "input": "---\n\"id\" \n1 \n\n3\n---",
+          "input": "###\n\"id\" \n1 \n\n3\n---",
           "output": [{ "id": 1 }, { "id": 3 }]
         }
       ]
@@ -153,7 +153,7 @@
       "description": "should parse a nested table",
       "tests": [
         {
-          "input": "{\n\"data\": ---\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---\n  }",
+          "input": "{\n\"data\": ###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---\n  }",
           "output": {
             "data": [
               { "id": 1, "name": "Joe" },
@@ -220,7 +220,7 @@
       "description": "parse a table containing nested arrays",
       "tests": [
         {
-          "input": "---\n\"id\", \"name\", \"score\"\n1, \"joe\", [5, 7]\n2, \"sarah\", [7, 7, 8]\n---",
+          "input": "###\n\"id\", \"name\", \"score\"\n1, \"joe\", [5, 7]\n2, \"sarah\", [7, 7, 8]\n---",
           "output": [
             { "id": 1, "name": "joe", "score": [5, 7] },
             { "id": 2, "name": "sarah", "score": [7, 7, 8] }
@@ -233,7 +233,7 @@
       "description": "parse a root containing nested objects",
       "tests": [
         {
-          "input": "---\n\"id\", \"name\", \"address\"\n1, \"Joe\", { \"city\": \"New York\", \"street\": \"1st Ave\" }\n2, \"Sarah\", { \"city\": \"Washington\", \"street\": \"18th Street NW\" }\n---",
+          "input": "###\n\"id\", \"name\", \"address\"\n1, \"Joe\", { \"city\": \"New York\", \"street\": \"1st Ave\" }\n2, \"Sarah\", { \"city\": \"Washington\", \"street\": \"18th Street NW\" }\n---",
           "output": [
             { "id": 1, "name": "Joe", "address": { "city": "New York", "street": "1st Ave" } },
             {
@@ -250,7 +250,7 @@
       "description": "parse a table containing a nested table ",
       "tests": [
         {
-          "input": "{\n  \"runs\": ---\n    \"data\", \"run-id\"\n    ---\n      \"time\", \"voltage\", \"current\"\n      1,      0.7,       -5.5\n      2,      0.7,       -7.5\n    ---,1\n  ---\n}",
+          "input": "{\n  \"runs\": ###\n    \"data\", \"run-id\"\n    ###\n      \"time\", \"voltage\", \"current\"\n      1,      0.7,       -5.5\n      2,      0.7,       -7.5\n    ---,1\n  ---\n}",
           "output": {
             "runs": [
               {

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -348,12 +348,26 @@
       "description": "throw a clear error when a table start is not followed by a newline",
       "tests": [
         {
-          "input": "---\"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"\n---",
-          "throws": "Newline '\\n' expected after table row but got '\"' at position 3"
+          "input": "(\"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"\n)",
+          "throws": "Newline '\\n' expected after table row but got '\"' at position 1"
         },
         {
-          "input": "---  /* comment */  \"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"\n---",
-          "throws": "Newline '\\n' expected after table row but got '\"' at position 20"
+          "input": "(  /* comment */  \"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"\n)",
+          "throws": "Newline '\\n' expected after table row but got '\"' at position 18"
+        }
+      ]
+    },
+    {
+      "category": "table",
+      "description": "throw a clear error when a table end is not preceded by a newline",
+      "tests": [
+        {
+          "input": "(\n\"id\",\"name\"\n2,\"joe\"\n3,\"sarah\")",
+          "throws": "Newline '\\n' expected after table row but got ')' at position 31"
+        },
+        {
+          "input": "(\n\"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"  /* comment */  )",
+          "throws": "Newline '\\n' expected after table row but got ')' at position 48"
         }
       ]
     },

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -291,14 +291,13 @@
           "output": {
             "data": [
               {
-                "value": [ {"nested": true} ]
+                "value": [{ "nested": true }]
               },
               {
-                "value": [ {"nested": true} ]
+                "value": [{ "nested": true }]
               }
             ]
           }
-
         }
       ]
     },

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -331,6 +331,19 @@
       ]
     },
     {
+      "category": "table",
+      "description": "parse deprecated table syntax using triple minus sign ---",
+      "tests": [
+        {
+          "input": "---\n\"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"\n---",
+          "output": [
+            { "id": 2, "name": "joe" },
+            { "id": 3, "name": "sarah" }
+          ]
+        }
+      ]
+    },
+    {
       "category": "number",
       "description": "should parse a number",
       "tests": [

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -75,7 +75,7 @@
       "description": "should parse a table",
       "tests": [
         {
-          "input": "###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---",
+          "input": "(\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n)",
           "output": [
             { "id": 1, "name": "Joe" },
             { "id": 2, "name": "Sarah" }
@@ -88,7 +88,7 @@
       "description": "should parse a table with \\r\\n newlines",
       "tests": [
         {
-          "input": "###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---",
+          "input": "(\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n)",
           "output": [
             { "id": 1, "name": "Joe" },
             { "id": 2, "name": "Sarah" }
@@ -101,7 +101,7 @@
       "description": "should parse a table with nested properties",
       "tests": [
         {
-          "input": "###\n    \"id\",\"name\",\"address\".\"city\",\"address\".\"street\"\n    1,\"Joe\",\"New York\",\"1st Ave\"\n    2,\"Sarah\",\"Washington\",\"18th Street NW\"\n    ---",
+          "input": "(\n    \"id\",\"name\",\"address\".\"city\",\"address\".\"street\"\n    1,\"Joe\",\"New York\",\"1st Ave\"\n    2,\"Sarah\",\"Washington\",\"18th Street NW\"\n    )",
           "output": [
             { "id": 1, "name": "Joe", "address": { "city": "New York", "street": "1st Ave" } },
             {
@@ -118,7 +118,7 @@
       "description": "should parse a table with whitespace",
       "tests": [
         {
-          "input": "###\n      \"id\" , \"details\" . \"name\" \n      1 , \"Joe\" \n      2 , \"Sarah\" \n      ---",
+          "input": "(\n      \"id\" , \"details\" . \"name\" \n      1 , \"Joe\" \n      2 , \"Sarah\" \n      )",
           "output": [
             { "id": 1, "details": { "name": "Joe" } },
             { "id": 2, "details": { "name": "Sarah" } }
@@ -131,7 +131,7 @@
       "description": "should parse a table with missing values",
       "tests": [
         {
-          "input": "###\n\"id\", \"name\"\n1 , \n2 , \"Sarah\" \n---",
+          "input": "(\n\"id\", \"name\"\n1 , \n2 , \"Sarah\" \n)",
           "output": [{ "id": 1 }, { "id": 2, "name": "Sarah" }]
         },
         {
@@ -139,11 +139,11 @@
           "output": [{ "id": 1, "name": "Joe" }, { "name": "Sarah" }]
         },
         {
-          "input": "###\n\"id\", \"name\" \n1 , \"Joe\" \n, \"Sarah\" \n---",
+          "input": "(\n\"id\", \"name\" \n1 , \"Joe\" \n, \"Sarah\" \n)",
           "output": [{ "id": 1, "name": "Joe" }, { "name": "Sarah" }]
         },
         {
-          "input": "###\n\"id\" \n1 \n\n3\n---",
+          "input": "(\n\"id\" \n1 \n\n3\n)",
           "output": [{ "id": 1 }, { "id": 3 }]
         }
       ]
@@ -153,7 +153,7 @@
       "description": "should parse a nested table",
       "tests": [
         {
-          "input": "{\n\"data\": ###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---\n  }",
+          "input": "{\n\"data\": (\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n)\n  }",
           "output": {
             "data": [
               { "id": 1, "name": "Joe" },
@@ -220,7 +220,7 @@
       "description": "parse a table containing nested arrays",
       "tests": [
         {
-          "input": "###\n\"id\", \"name\", \"score\"\n1, \"joe\", [5, 7]\n2, \"sarah\", [7, 7, 8]\n---",
+          "input": "(\n\"id\", \"name\", \"score\"\n1, \"joe\", [5, 7]\n2, \"sarah\", [7, 7, 8]\n)",
           "output": [
             { "id": 1, "name": "joe", "score": [5, 7] },
             { "id": 2, "name": "sarah", "score": [7, 7, 8] }
@@ -233,7 +233,7 @@
       "description": "parse a root containing nested objects",
       "tests": [
         {
-          "input": "###\n\"id\", \"name\", \"address\"\n1, \"Joe\", { \"city\": \"New York\", \"street\": \"1st Ave\" }\n2, \"Sarah\", { \"city\": \"Washington\", \"street\": \"18th Street NW\" }\n---",
+          "input": "(\n\"id\", \"name\", \"address\"\n1, \"Joe\", { \"city\": \"New York\", \"street\": \"1st Ave\" }\n2, \"Sarah\", { \"city\": \"Washington\", \"street\": \"18th Street NW\" }\n)",
           "output": [
             { "id": 1, "name": "Joe", "address": { "city": "New York", "street": "1st Ave" } },
             {
@@ -250,7 +250,7 @@
       "description": "parse a table containing a nested table (1)",
       "tests": [
         {
-          "input": "{\n  \"data\": ###\n    \"values\"\n    ###\n      \"value\"\n      1\n      2\n    ---\n  ---\n}\n",
+          "input": "{\n  \"data\": (\n    \"values\"\n    (\n      \"value\"\n      1\n      2\n    )\n  )\n}\n",
           "output": {
             "data": [
               {
@@ -266,7 +266,7 @@
       "description": "parse a table containing a nested table (2)",
       "tests": [
         {
-          "input": "{\n  \"runs\": ###\n    \"id\", \"data\"\n    \"1\",  ###\n      \"value\"\n      7.9\n    ---\n    \"2\",  ###\n      \"value\"\n      7.8\n    ---\n  ---\n}",
+          "input": "{\n  \"runs\": (\n    \"id\", \"data\"\n    \"1\",  (\n      \"value\"\n      7.9\n    )\n    \"2\",  (\n      \"value\"\n      7.8\n    )\n  )\n}",
           "output": {
             "runs": [
               {
@@ -287,7 +287,7 @@
       "description": "parse a table containing a nested table (3)",
       "tests": [
         {
-          "input": "{\n  \"data\": ###\n    \"value\"\n    ###\n      \"nested\"\n      true\n    ---\n    ###\n      \"nested\"\n      true\n    ---\n  ---\n}\n",
+          "input": "{\n  \"data\": (\n    \"value\"\n    (\n      \"nested\"\n      true\n    )\n    (\n      \"nested\"\n      true\n    )\n  )\n}\n",
           "output": {
             "data": [
               {

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -344,6 +344,20 @@
       ]
     },
     {
+      "category": "table",
+      "description": "throw a clear error when a table start is not followed by a newline",
+      "tests": [
+        {
+          "input": "---\"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"\n---",
+          "throws": "Newline '\\n' expected after table row but got '\"' at position 3"
+        },
+        {
+          "input": "---  /* comment */  \"id\",\"name\"\n2,\"joe\"\n3,\"sarah\"\n---",
+          "throws": "Newline '\\n' expected after table row but got '\"' at position 20"
+        }
+      ]
+    },
+    {
       "category": "number",
       "description": "should parse a number",
       "tests": [

--- a/test-suite/parse.test.json
+++ b/test-suite/parse.test.json
@@ -284,6 +284,26 @@
     },
     {
       "category": "table",
+      "description": "parse a table containing a nested table (3)",
+      "tests": [
+        {
+          "input": "{\n  \"data\": ###\n    \"value\"\n    ###\n      \"nested\"\n      true\n    ---\n    ###\n      \"nested\"\n      true\n    ---\n  ---\n}\n",
+          "output": {
+            "data": [
+              {
+                "value": [ {"nested": true} ]
+              },
+              {
+                "value": [ {"nested": true} ]
+              }
+            ]
+          }
+
+        }
+      ]
+    },
+    {
+      "category": "table",
       "description": "parse a root table with field names that are escaped",
       "tests": [
         {

--- a/test-suite/stringify.test.json
+++ b/test-suite/stringify.test.json
@@ -152,7 +152,7 @@
               { "id": 2, "name": "Sarah" }
             ]
           },
-          "output": "{\"data\":---\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---}"
+          "output": "{\"data\":###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---}"
         }
       ]
     },
@@ -170,7 +170,7 @@
               { "id": 2, "name": "Sarah" }
             ]
           },
-          "output": "{\n  \"data\": ---\n    \"id\", \"name\"\n    1,    \"Joe\"\n    2,    \"Sarah\"\n  ---\n}"
+          "output": "{\n  \"data\": ###\n    \"id\", \"name\"\n    1,    \"Joe\"\n    2,    \"Sarah\"\n  ---\n}"
         }
       ]
     },
@@ -195,7 +195,7 @@
               { "id": 2, "name": "Sarah", "friends": [] }
             ]
           },
-          "output": "{\n  \"data\": ---\n    \"id\", \"name\",  \"friends\"\n    1,    \"Joe\",   ---\n      \"id\", \"name\"\n      3,    \"Kevin\"\n      2,    \"Sarah\"\n    ---\n    2,    \"Sarah\", []\n  ---\n}"
+          "output": "{\n  \"data\": ###\n    \"id\", \"name\",  \"friends\"\n    1,    \"Joe\",   ###\n      \"id\", \"name\"\n      3,    \"Kevin\"\n      2,    \"Sarah\"\n    ---\n    2,    \"Sarah\", []\n  ---\n}"
         }
       ]
     },
@@ -213,7 +213,7 @@
               { "id": 2, "name": "Sarah" }
             ]
           },
-          "output": "{\n~~\"data\": ---\n~~~~\"id\", \"name\"\n~~~~1,    \"Joe\"\n~~~~2,    \"Sarah\"\n~~---\n}"
+          "output": "{\n~~\"data\": ###\n~~~~\"id\", \"name\"\n~~~~1,    \"Joe\"\n~~~~2,    \"Sarah\"\n~~---\n}"
         }
       ]
     },
@@ -235,7 +235,7 @@
               }
             ]
           },
-          "output": "{\n  \"data\": ---\n    \"id\", \"name\",  \"address\".\"city\", \"address\".\"street\"\n    1,    \"Joe\",   \"New York\",       \"1st Ave\"\n    2,    \"Sarah\", \"Washington\",     \"18th Street NW\"\n  ---\n}"
+          "output": "{\n  \"data\": ###\n    \"id\", \"name\",  \"address\".\"city\", \"address\".\"street\"\n    1,    \"Joe\",   \"New York\",       \"1st Ave\"\n    2,    \"Sarah\", \"Washington\",     \"18th Street NW\"\n  ---\n}"
         }
       ]
     },
@@ -276,7 +276,7 @@
               { "id": 2, "address": {} }
             ]
           },
-          "output": "{\n  \"data\": ---\n    \"id\", \"address\".\"city\"\n    1,    \"New York\"\n    2,    \n  ---\n}"
+          "output": "{\n  \"data\": ###\n    \"id\", \"address\".\"city\"\n    1,    \"New York\"\n    2,    \n  ---\n}"
         },
         {
           "input": {
@@ -285,7 +285,7 @@
               { "id": 2, "address": "1st Ave, New York" }
             ]
           },
-          "output": "{\n  \"data\": ---\n    \"id\", \"address\"\n    1,    {\"city\":\"New York\"}\n    2,    \"1st Ave, New York\"\n  ---\n}"
+          "output": "{\n  \"data\": ###\n    \"id\", \"address\"\n    1,    {\"city\":\"New York\"}\n    2,    \"1st Ave, New York\"\n  ---\n}"
         }
       ]
     },
@@ -319,7 +319,7 @@
               { "id": 2, "scores": [7.7] }
             ]
           },
-          "output": "{\n  \"data\": ---\n    \"id\", \"scores\"\n    1,    [7.2,6.1,8.1]\n    2,    [7.7]\n  ---\n}"
+          "output": "{\n  \"data\": ###\n    \"id\", \"scores\"\n    1,    [7.2,6.1,8.1]\n    2,    [7.7]\n  ---\n}"
         }
       ]
     },
@@ -335,7 +335,7 @@
             { "id": 1, "scores": [{ "value": 7.2 }, { "value": 6.1 }, { "value": 8.1 }] },
             { "id": 2, "scores": [{ "value": 7.7 }] }
           ],
-          "output": "\"id\", \"scores\"\n1,    ---\n  \"value\"\n  7.2\n  6.1\n  8.1\n---\n2,    ---\n  \"value\"\n  7.7\n---\n"
+          "output": "\"id\", \"scores\"\n1,    ###\n  \"value\"\n  7.2\n  6.1\n  8.1\n---\n2,    ###\n  \"value\"\n  7.7\n---\n"
         }
       ]
     },
@@ -353,7 +353,7 @@
               { "id": 2, "scores": [{ "value": 7.7 }] }
             ]
           },
-          "output": "{\n  \"data\": ---\n    \"id\", \"scores\"\n    1,    ---\n      \"value\"\n      7.2\n      6.1\n      8.1\n    ---\n    2,    ---\n      \"value\"\n      7.7\n    ---\n  ---\n}"
+          "output": "{\n  \"data\": ###\n    \"id\", \"scores\"\n    1,    ###\n      \"value\"\n      7.2\n      6.1\n      8.1\n    ---\n    2,    ###\n      \"value\"\n      7.7\n    ---\n  ---\n}"
         },
         {
           "input": [
@@ -363,7 +363,7 @@
               "finished": false
             }
           ],
-          "output": "\"id\", \"measurements\", \"finished\"\n1,    ---\n  \"t\", \"temperature\", \"humidity\"\n  1,   23,            0.4\n---,false\n"
+          "output": "\"id\", \"measurements\", \"finished\"\n1,    ###\n  \"t\", \"temperature\", \"humidity\"\n  1,   23,            0.4\n---,false\n"
         }
       ]
     },

--- a/test-suite/stringify.test.json
+++ b/test-suite/stringify.test.json
@@ -152,7 +152,7 @@
               { "id": 2, "name": "Sarah" }
             ]
           },
-          "output": "{\"data\":###\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n---}"
+          "output": "{\"data\":(\n\"id\",\"name\"\n1,\"Joe\"\n2,\"Sarah\"\n)}"
         }
       ]
     },
@@ -170,7 +170,7 @@
               { "id": 2, "name": "Sarah" }
             ]
           },
-          "output": "{\n  \"data\": ###\n    \"id\", \"name\"\n    1,    \"Joe\"\n    2,    \"Sarah\"\n  ---\n}"
+          "output": "{\n  \"data\": (\n    \"id\", \"name\"\n    1,    \"Joe\"\n    2,    \"Sarah\"\n  )\n}"
         }
       ]
     },
@@ -195,7 +195,7 @@
               { "id": 2, "name": "Sarah", "friends": [] }
             ]
           },
-          "output": "{\n  \"data\": ###\n    \"id\", \"name\",  \"friends\"\n    1,    \"Joe\",   ###\n      \"id\", \"name\"\n      3,    \"Kevin\"\n      2,    \"Sarah\"\n    ---\n    2,    \"Sarah\", []\n  ---\n}"
+          "output": "{\n  \"data\": (\n    \"id\", \"name\",  \"friends\"\n    1,    \"Joe\",   (\n      \"id\", \"name\"\n      3,    \"Kevin\"\n      2,    \"Sarah\"\n    )\n    2,    \"Sarah\", []\n  )\n}"
         }
       ]
     },
@@ -213,7 +213,7 @@
               { "id": 2, "name": "Sarah" }
             ]
           },
-          "output": "{\n~~\"data\": ###\n~~~~\"id\", \"name\"\n~~~~1,    \"Joe\"\n~~~~2,    \"Sarah\"\n~~---\n}"
+          "output": "{\n~~\"data\": (\n~~~~\"id\", \"name\"\n~~~~1,    \"Joe\"\n~~~~2,    \"Sarah\"\n~~)\n}"
         }
       ]
     },
@@ -235,7 +235,7 @@
               }
             ]
           },
-          "output": "{\n  \"data\": ###\n    \"id\", \"name\",  \"address\".\"city\", \"address\".\"street\"\n    1,    \"Joe\",   \"New York\",       \"1st Ave\"\n    2,    \"Sarah\", \"Washington\",     \"18th Street NW\"\n  ---\n}"
+          "output": "{\n  \"data\": (\n    \"id\", \"name\",  \"address\".\"city\", \"address\".\"street\"\n    1,    \"Joe\",   \"New York\",       \"1st Ave\"\n    2,    \"Sarah\", \"Washington\",     \"18th Street NW\"\n  )\n}"
         }
       ]
     },
@@ -276,7 +276,7 @@
               { "id": 2, "address": {} }
             ]
           },
-          "output": "{\n  \"data\": ###\n    \"id\", \"address\".\"city\"\n    1,    \"New York\"\n    2,    \n  ---\n}"
+          "output": "{\n  \"data\": (\n    \"id\", \"address\".\"city\"\n    1,    \"New York\"\n    2,    \n  )\n}"
         },
         {
           "input": {
@@ -285,7 +285,7 @@
               { "id": 2, "address": "1st Ave, New York" }
             ]
           },
-          "output": "{\n  \"data\": ###\n    \"id\", \"address\"\n    1,    {\"city\":\"New York\"}\n    2,    \"1st Ave, New York\"\n  ---\n}"
+          "output": "{\n  \"data\": (\n    \"id\", \"address\"\n    1,    {\"city\":\"New York\"}\n    2,    \"1st Ave, New York\"\n  )\n}"
         }
       ]
     },
@@ -319,7 +319,7 @@
               { "id": 2, "scores": [7.7] }
             ]
           },
-          "output": "{\n  \"data\": ###\n    \"id\", \"scores\"\n    1,    [7.2,6.1,8.1]\n    2,    [7.7]\n  ---\n}"
+          "output": "{\n  \"data\": (\n    \"id\", \"scores\"\n    1,    [7.2,6.1,8.1]\n    2,    [7.7]\n  )\n}"
         }
       ]
     },
@@ -335,7 +335,7 @@
             { "id": 1, "scores": [{ "value": 7.2 }, { "value": 6.1 }, { "value": 8.1 }] },
             { "id": 2, "scores": [{ "value": 7.7 }] }
           ],
-          "output": "\"id\", \"scores\"\n1,    ###\n  \"value\"\n  7.2\n  6.1\n  8.1\n---\n2,    ###\n  \"value\"\n  7.7\n---\n"
+          "output": "\"id\", \"scores\"\n1,    (\n  \"value\"\n  7.2\n  6.1\n  8.1\n)\n2,    (\n  \"value\"\n  7.7\n)\n"
         }
       ]
     },
@@ -353,7 +353,7 @@
               { "id": 2, "scores": [{ "value": 7.7 }] }
             ]
           },
-          "output": "{\n  \"data\": ###\n    \"id\", \"scores\"\n    1,    ###\n      \"value\"\n      7.2\n      6.1\n      8.1\n    ---\n    2,    ###\n      \"value\"\n      7.7\n    ---\n  ---\n}"
+          "output": "{\n  \"data\": (\n    \"id\", \"scores\"\n    1,    (\n      \"value\"\n      7.2\n      6.1\n      8.1\n    )\n    2,    (\n      \"value\"\n      7.7\n    )\n  )\n}"
         },
         {
           "input": [
@@ -363,7 +363,7 @@
               "finished": false
             }
           ],
-          "output": "\"id\", \"measurements\", \"finished\"\n1,    ###\n  \"t\", \"temperature\", \"humidity\"\n  1,   23,            0.4\n---,false\n"
+          "output": "\"id\", \"measurements\", \"finished\"\n1,    (\n  \"t\", \"temperature\", \"humidity\"\n  1,   23,            0.4\n),false\n"
         }
       ]
     },


### PR DESCRIPTION
Fixes #15 

BREAKING CHANGES:

- Changes the table syntax from `---...---` to `(...)`. The change is backward compatible. You can parse tables in both the old and new format, but stringifying data will now output tables with the new syntax.